### PR TITLE
Fix publish workflow version extraction step order

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,16 +39,16 @@ jobs:
       - name: Pack
         run: dotnet pack src/Samsara.Net/Samsara.Net.csproj -c Release --no-build --no-restore
 
-      - name: Publish to NuGet
-        env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-        run: dotnet nuget push src/Samsara.Net/bin/Release/*.nupkg --api-key $NUGET_API_KEY --source "nuget.org"
-
       - name: Extract version
         id: version
         run: |
           VERSION=$(grep 'public const string Current' src/Samsara.Net/Core/Public/Version.cs | sed 's/.*"\(.*\)".*/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Publish to NuGet
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push src/Samsara.Net/bin/Release/*.nupkg --api-key $NUGET_API_KEY --source "nuget.org"
 
       - name: Notify Slack - .NET SDK published
         if: success()


### PR DESCRIPTION
Move **Extract version** before **Publish to NuGet** so that a `grep` failure against `Version.cs` does not produce a false-negative Slack alert after a successful publish.

Previously, if the version extraction step failed _after_ a successful NuGet push, the job would report failure and the `:x:` Slack notification would fire — even though the package was already published.

Addresses [review feedback from #93](https://github.com/samsarahq/samsara-dotnet/pull/93#issuecomment-2831875461).

API-6688

Made with [Cursor](https://cursor.com)